### PR TITLE
Signal abstraction fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+Cargo.lock
+target/*

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,8 @@
 //!
 //! # Example
 //!
-//! ```ignore
+//! ```
+//! let my_future = async {};
 //! let result = pollster::block_on(my_future);
 //! ```
 
@@ -14,28 +15,69 @@ use std::{
     sync::{Condvar, Mutex, Arc},
 };
 
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+enum SignalState {
+    Empty,
+    Waiting,
+    Notified,
+}
+
 struct Signal {
-    lock: Mutex<bool>,
+    state: Mutex<SignalState>,
     cond: Condvar,
 }
 
 impl Signal {
-    // Wait for a notification
-    fn wait(&self) {
-        let mut wakeup = self.lock.lock().unwrap();
-        if !*wakeup {
-            // Signal was notified since the last wakeup, so don't wait. This flag avoids 'missed'
-            // notifications that might occur when we're not waiting.
-            wakeup = self.cond.wait(wakeup).unwrap();
+    fn new() -> Self {
+        Self {
+            state: Mutex::new(SignalState::Empty),
+            cond: Condvar::new(),
         }
-        *wakeup = false;
     }
 
-    // Notify the thread that's waiting on this signal
+    fn wait(&self) {
+        let mut state = self.state.lock().unwrap();
+
+        // notify() was called before us, cosume it here without waiting.
+        if *state == SignalState::Notified {
+            *state = SignalState::Empty;
+            return;
+        }
+        
+        // state is either Empty or Waiting.
+        // no other thread should be Waiting
+        debug_assert_eq!(
+            *state,
+            SignalState::Empty,
+            "Multiple threads waiting on same Signal",
+        );
+
+        // Wait on the state until its reset back to Empty.
+        // Done in a loop to handle Condvar spurious wakeups
+        *state = SignalState::Waiting;
+        while *state == SignalState::Waiting {
+            state = self.cond.wait(state).unwrap();
+        }
+    }
+
     fn notify(&self) {
-        let mut wakeup = self.lock.lock().unwrap();
-        *wakeup = true;
-        self.cond.notify_one();
+        let mut state = self.state.lock().unwrap();
+
+        match *state {
+            // The signal was already notified
+            SignalState::Notified => {},
+
+            // The signal wasnt notified but a thread isnt waiting on it
+            // so no need to call into the Condvar to wake one up
+            SignalState::Empty => *state = SignalState::Notified,
+
+            // The signal wasnt notified and theres a waiting thread.
+            // Reset the signal so it can be wait()'ed on again & wake up the thread.
+            SignalState::Waiting => {
+                *state = SignalState::Empty;
+                self.cond.notify_one();
+            },
+        }
     }
 }
 
@@ -60,15 +102,13 @@ static VTABLE: RawWakerVTable = unsafe { RawWakerVTable::new(
 ///
 /// # Example
 ///
-/// ```ignore
+/// ```
+/// let my_future = async {};
 /// let result = pollster::block_on(my_future);
 /// ```
 pub fn block_on<F: Future>(mut fut: F) -> F::Output {
     // Signal used to wake up the thread for polling as the future moves to completion.
-    let signal = Arc::new(Signal {
-        lock: Mutex::new(false),
-        cond: Condvar::new(),
-    });
+    let signal = Arc::new(Signal::new());
 
     // Safe because the `Arc` is cloned and is still considered to have an owner until dropped in
     // the `RawWakerVTable` above.


### PR DESCRIPTION
The Signal struct used to wake up a blocked thread doesn't handle spurious wake-ups as described by [Condvar](https://doc.rust-lang.org/src/std/sync/condvar.rs.html#146-149) and also may perform an unnecessary call to `Condvar::notify_one()` if the `notify()` thread acquires the lock before the `wait()` thread. 

This adds an intermediate state which makes the Signal functions aware if the signal is already notified or has a waiting thread in order to know when to perform Condvar calls and uses a while loop to handle spurious wakeups.