### PR TITLE
Update dev-dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,5 @@ license = "Apache-2.0/MIT"
 readme = "README.md"
 
 [dev-dependencies]
-async-std = "1.5"
 futures-timer = "3.0"
 tokio = { version = "0.2", features = ["sync"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,4 +12,4 @@ readme = "README.md"
 
 [dev-dependencies]
 futures-timer = "3.0"
-tokio = { version = "0.2", features = ["sync"] }
+tokio = { version = "1", features = ["sync"] }

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -3,7 +3,7 @@ use std::time::{Duration, Instant};
 
 #[test]
 fn basic() {
-    let make_fut = || async_std::future::ready(42);
+    let make_fut = || std::future::ready(42);
 
     // Immediately ready
     assert_eq!(pollster::block_on(make_fut()), 42);

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -25,8 +25,8 @@ fn mpsc() {
     const BOUNDED: usize = 16;
     const MESSAGES: usize = 100_000;
 
-    let (mut a_tx, mut a_rx) = mpsc::channel(BOUNDED);
-    let (mut b_tx, mut b_rx) = mpsc::channel(BOUNDED);
+    let (a_tx, mut a_rx) = mpsc::channel(BOUNDED);
+    let (b_tx, mut b_rx) = mpsc::channel(BOUNDED);
 
     let thread_a = thread::spawn(move || {
         pollster::block_on(async {


### PR DESCRIPTION
- Removes `async_std` since it was only used for `future::ready` in a test, which has since been added to std in [`1.48.0`](https://doc.rust-lang.org/std/future/fn.ready.html).
- Updates `tokio` to v1.