### PR TITLE
Add proc-macro

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,3 +20,14 @@ jobs:
       run: cargo build --verbose
     - name: Run tests
       run: cargo test --verbose
+
+  build-with-macro:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Build
+      run: cargo build --features macro --verbose
+    - name: Run tests
+      run: cargo test --features macro --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,11 @@ pollster-macro = { version = "0.1", path = "macro", optional = true }
 [dev-dependencies]
 futures-timer = "3.0"
 tokio = { version = "1", features = ["sync"] }
+
+[[test]]
+name = "main"
+required-features = ["macro"]
+
+[[test]]
+name = "test"
+required-features = ["macro"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,3 +1,7 @@
+[workspace]
+members = ["", "macro"]
+default-members = [""]
+
 [package]
 name = "pollster"
 version = "0.2.5"
@@ -9,6 +13,12 @@ authors = ["Joshua Barretto <joshua.s.barretto@gmail.com>"]
 edition = "2018"
 license = "Apache-2.0/MIT"
 readme = "README.md"
+
+[features]
+macro = ["pollster-macro"]
+
+[dependencies]
+pollster-macro = { version = "0.1", path = "macro", optional = true }
 
 [dev-dependencies]
 futures-timer = "3.0"

--- a/README.md
+++ b/README.md
@@ -47,3 +47,27 @@ Unfortunately, `pollster` will not work for *all* futures because some require a
 information about when and where `pollster` may be used. However, if you're already pulling in the required dependencies
 to create such a future in the first place, it's likely that you already have a version of `block_on` in your dependency
 tree that's designed to poll your future, so use that instead.
+
+## Macro
+
+When using the `macro` crate feature, an attribute-macro can be used to mark `async fn main()`:
+```rust,ignore
+#[pollster::main]
+async fn main() {
+    let my_fut = async {};
+
+    my_fut.await;
+}
+```
+
+Additionally if you have re-exported the crate with a different name then `pollster`, you have to specify it:
+```rust,ignore
+#[pollster::main(crate = "renamed-pollster")]
+async fn main() {
+    let my_fut = async {};
+
+    my_fut.await;
+}
+```
+
+You can also use `#[pollster::test]` for tests.

--- a/macro/Cargo.toml
+++ b/macro/Cargo.toml
@@ -12,3 +12,12 @@ readme = "README.md"
 
 [lib]
 proc-macro = true
+
+[dependencies]
+proc-macro2 = "1"
+quote = { version = "1", default-features = false }
+syn = { version = "1", default-features = false, features = [
+    "full",
+    "parsing",
+    "printing",
+] }

--- a/macro/Cargo.toml
+++ b/macro/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "pollster-macro"
+version = "0.1.0"
+description = "Proc-macro crate for pollster"
+categories = ["asynchronous", "concurrency"]
+keywords = ["async", "minimal", "executor", "runtime", "block_on"]
+repository = "https://github.com/zesterer/pollster"
+authors = ["Joshua Barretto <joshua.s.barretto@gmail.com>"]
+edition = "2018"
+license = "Apache-2.0/MIT"
+readme = "README.md"
+
+[lib]
+proc-macro = true

--- a/macro/LICENSE-APACHE
+++ b/macro/LICENSE-APACHE
@@ -1,0 +1,1 @@
+../LICENSE-APACHE

--- a/macro/LICENSE-MIT
+++ b/macro/LICENSE-MIT
@@ -1,0 +1,1 @@
+../LICENSE-MIT

--- a/macro/README.md
+++ b/macro/README.md
@@ -1,0 +1,1 @@
+../README.md

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -8,6 +8,18 @@ use quote::{quote_spanned, ToTokens};
 use syn::parse::{Parse, ParseStream};
 use syn::{AttributeArgs, Error, ItemFn, Lit, Meta, MetaNameValue, NestedMeta, Result};
 
+/// Uses [`pollster::block_on`] to enable `async fn main() {}`.
+///
+/// # Example
+///
+/// ```
+/// #[pollster::main]
+/// async fn main() {
+///     let my_fut = async {};
+///
+///     my_fut.await;
+/// }
+/// ```
 #[proc_macro_attribute]
 pub fn main(
     attr: proc_macro::TokenStream,
@@ -22,6 +34,18 @@ pub fn main(
     }
 }
 
+/// Uses [`pollster::block_on`] to enable `async` on test functions.
+///
+/// # Example
+///
+/// ```ignore
+/// #[pollster::test]
+/// async fn main() {
+///     let my_fut = async {};
+///
+///     my_fut.await;
+/// }
+/// ```
 #[proc_macro_attribute]
 pub fn test(
     attr: proc_macro::TokenStream,

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -1,64 +1,114 @@
 #![doc = include_str!("../README.md")]
 
 use std::iter::FromIterator;
+use std::str::FromStr;
 
 use proc_macro2::TokenStream;
-use quote::ToTokens;
-use syn::{Error, ItemFn, Result};
+use quote::{quote_spanned, ToTokens};
+use syn::parse::{Parse, ParseStream};
+use syn::{AttributeArgs, Error, ItemFn, Lit, Meta, MetaNameValue, NestedMeta, Result};
 
 #[proc_macro_attribute]
 pub fn main(
-    _attr: proc_macro::TokenStream,
+    attr: proc_macro::TokenStream,
     item: proc_macro::TokenStream,
 ) -> proc_macro::TokenStream {
-    relay(item, internal)
-}
-
-#[proc_macro_attribute]
-pub fn test(
-    _attr: proc_macro::TokenStream,
-    item: proc_macro::TokenStream,
-) -> proc_macro::TokenStream {
-    relay(item, |item| {
-        let mut item = internal(item)?;
-        item.attrs.push(syn::parse_quote! { #[test] });
-
-        Ok(item)
-    })
-}
-
-fn relay(
-    item: proc_macro::TokenStream,
-    fun: impl FnOnce(TokenStream) -> Result<ItemFn>,
-) -> proc_macro::TokenStream {
+    let item = item;
     let item = TokenStream::from(item);
-    let backup = item.clone();
+    let mut backup = item.clone();
 
-    match fun(item) {
+    match common(&mut backup, attr.into(), item) {
         Ok(output) => output.into_token_stream().into(),
         Err(error) => TokenStream::from_iter([error.into_compile_error(), backup]).into(),
     }
 }
 
-fn internal(item: TokenStream) -> Result<ItemFn> {
+#[proc_macro_attribute]
+pub fn test(
+    attr: proc_macro::TokenStream,
+    item: proc_macro::TokenStream,
+) -> proc_macro::TokenStream {
+    let item = item;
+    let item = TokenStream::from(item);
+    let mut backup = item.clone();
+
+    match test_internal(&mut backup, attr.into(), item) {
+        Ok(output) => output.into_token_stream().into(),
+        Err(error) => TokenStream::from_iter([error.into_compile_error(), backup]).into(),
+    }
+}
+
+fn test_internal(backup: &mut TokenStream, attr: TokenStream, item: TokenStream) -> Result<ItemFn> {
+    let mut item = common(backup, attr, item)?;
+    item.attrs.push(syn::parse_quote! { #[test] });
+
+    Ok(item)
+}
+
+fn common(backup: &mut TokenStream, attr: TokenStream, item: TokenStream) -> Result<ItemFn> {
     let mut item: ItemFn = syn::parse2(item)?;
     let span = item.block.brace_token.span;
 
     if item.sig.asyncness.is_some() {
         item.sig.asyncness = None;
+        *backup = item.to_token_stream();
     } else {
         return Err(Error::new_spanned(item, "expected function to be async"));
     }
+
+    let attr: Attr = syn::parse2(attr)?;
+    let mut crate_name = None;
+
+    for meta in attr.0 {
+        if let NestedMeta::Meta(Meta::NameValue(MetaNameValue {
+            path,
+            lit: Lit::Str(name),
+            ..
+        })) = meta
+        {
+            if path.is_ident("crate") {
+                let span = name.span();
+                let name = TokenStream::from_str(&name.value())?;
+
+                if crate_name
+                    .replace(quote_spanned! { span => #name})
+                    .is_some()
+                {
+                    return Err(Error::new(span, "found duplicate crate attribute"));
+                }
+
+                continue;
+            }
+        }
+
+        return Err(Error::new_spanned(item, "main(crate = \"package-name\")"));
+    }
+
+    let crate_name = crate_name.unwrap_or_else(|| quote::quote! { ::pollster });
 
     let block = item.block;
     item.block = syn::parse_quote_spanned! {
         span =>
         {
-            ::pollster::block_on(async {
+            #crate_name::block_on(async {
                 #block
             })
         }
     };
 
     Ok(item)
+}
+
+struct Attr(AttributeArgs);
+
+impl Parse for Attr {
+    fn parse(input: ParseStream) -> Result<Self> {
+        let mut attr = Vec::new();
+
+        while let Ok(meta) = input.parse() {
+            attr.push(meta)
+        }
+
+        Ok(Self(attr))
+    }
 }

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -1,0 +1,2 @@
+#![doc = include_str!("../README.md")]
+

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -1,2 +1,64 @@
 #![doc = include_str!("../README.md")]
 
+use std::iter::FromIterator;
+
+use proc_macro2::TokenStream;
+use quote::ToTokens;
+use syn::{Error, ItemFn, Result};
+
+#[proc_macro_attribute]
+pub fn main(
+    _attr: proc_macro::TokenStream,
+    item: proc_macro::TokenStream,
+) -> proc_macro::TokenStream {
+    relay(item, internal)
+}
+
+#[proc_macro_attribute]
+pub fn test(
+    _attr: proc_macro::TokenStream,
+    item: proc_macro::TokenStream,
+) -> proc_macro::TokenStream {
+    relay(item, |item| {
+        let mut item = internal(item)?;
+        item.attrs.push(syn::parse_quote! { #[test] });
+
+        Ok(item)
+    })
+}
+
+fn relay(
+    item: proc_macro::TokenStream,
+    fun: impl FnOnce(TokenStream) -> Result<ItemFn>,
+) -> proc_macro::TokenStream {
+    let item = TokenStream::from(item);
+    let backup = item.clone();
+
+    match fun(item) {
+        Ok(output) => output.into_token_stream().into(),
+        Err(error) => TokenStream::from_iter([error.into_compile_error(), backup]).into(),
+    }
+}
+
+fn internal(item: TokenStream) -> Result<ItemFn> {
+    let mut item: ItemFn = syn::parse2(item)?;
+    let span = item.block.brace_token.span;
+
+    if item.sig.asyncness.is_some() {
+        item.sig.asyncness = None;
+    } else {
+        return Err(Error::new_spanned(item, "expected function to be async"));
+    }
+
+    let block = item.block;
+    item.block = syn::parse_quote_spanned! {
+        span =>
+        {
+            ::pollster::block_on(async {
+                #block
+            })
+        }
+    };
+
+    Ok(item)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,6 +6,9 @@ use std::{
     task::{Context, Poll, Wake, Waker},
 };
 
+#[cfg(feature = "macro")]
+pub use pollster_macro::{main, test};
+
 /// An extension trait that allows blocking on a future in suffix position.
 pub trait FutureExt: Future {
     /// Block the thread until the future is ready.

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -1,6 +1,8 @@
+use std::future::ready;
+
 #[pollster::main]
 async fn main_basic() {
-    let _ = 42;
+    ready(42).await;
 }
 
 #[test]
@@ -10,7 +12,7 @@ fn basic() {
 
 #[pollster::main]
 async fn main_result() -> Result<(), std::io::Error> {
-    let _ = 42;
+    ready(42).await;
     Ok(())
 }
 
@@ -21,7 +23,7 @@ fn result() {
 
 #[pollster::main(crate = "pollster")]
 async fn main_crate() {
-    let _ = 42;
+    ready(42).await;
 }
 
 #[test]

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -1,0 +1,20 @@
+#[pollster::main]
+async fn main_basic() {
+    let _ = 42;
+}
+
+#[test]
+fn basic() {
+    main_basic();
+}
+
+#[pollster::main]
+async fn main_result() -> Result<(), std::io::Error> {
+    let _ = 42;
+    Ok(())
+}
+
+#[test]
+fn result() {
+    main_result().unwrap();
+}

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -18,3 +18,13 @@ async fn main_result() -> Result<(), std::io::Error> {
 fn result() {
     main_result().unwrap();
 }
+
+#[pollster::main(crate = "pollster")]
+async fn main_crate() {
+    let _ = 42;
+}
+
+#[test]
+fn crate_() {
+    main_crate();
+}

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -1,3 +1,5 @@
+extern crate pollster as reexported_pollster;
+
 use std::future::ready;
 
 #[pollster::main]
@@ -21,7 +23,7 @@ fn result() {
     main_result().unwrap();
 }
 
-#[pollster::main(crate = "pollster")]
+#[pollster::main(crate = "reexported_pollster")]
 async fn main_crate() {
     ready(42).await;
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,3 +1,5 @@
+extern crate pollster as reexported_pollster;
+
 use std::future::ready;
 
 #[pollster::test]
@@ -14,7 +16,7 @@ async fn result() -> Result<(), std::io::Error> {
     }
 }
 
-#[pollster::test(crate = "pollster")]
+#[pollster::test(crate = "reexported_pollster")]
 async fn crate_() {
     ready(42).await;
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,11 +1,13 @@
+use std::future::ready;
+
 #[pollster::test]
 async fn basic() {
-    assert_eq!(42, 42);
+    ready(42).await;
 }
 
 #[pollster::test]
 async fn result() -> Result<(), std::io::Error> {
-    if 42 == 42 {
+    if ready(42).await == 42 {
         Ok(())
     } else {
         unreachable!()
@@ -14,5 +16,5 @@ async fn result() -> Result<(), std::io::Error> {
 
 #[pollster::test(crate = "pollster")]
 async fn crate_() {
-    assert_eq!(42, 42);
+    ready(42).await;
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,0 +1,13 @@
+#[pollster::test]
+async fn basic() {
+    assert_eq!(42, 42);
+}
+
+#[pollster::test]
+async fn result() -> Result<(), std::io::Error> {
+    if 42 == 42 {
+        Ok(())
+    } else {
+        unreachable!()
+    }
+}

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -11,3 +11,8 @@ async fn result() -> Result<(), std::io::Error> {
         unreachable!()
     }
 }
+
+#[pollster::test(crate = "pollster")]
+async fn crate_() {
+    assert_eq!(42, 42);
+}


### PR DESCRIPTION
This adds `#[pollster::main]` and `#[pollster::test]`.

I was also careful to always return the inputted code back if we fail somewhere, otherwise Rust will complain in a binary that there is no `fn main()` function anywhere.

Additionally I introduced a `crate` attribute that enables defining a different path to `pollster` if it was renamed for some reason.

Please feel free to improve on the documentation, I am very tired right now, but my English isn't the best either.

I did try for a very long time to do this without `syn` or `quote`, it was fun, but brutal.

Fixes #10.