### PR TITLE
Fix clippy warnings

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,11 +49,8 @@ impl Signal {
     fn wait(&self) {
         let mut state = self.state.lock().unwrap();
         match *state {
-            SignalState::Notified => {
-                // Notify() was called before we got here, consume it here without waiting and return immediately.
-                *state = SignalState::Empty;
-                return;
-            }
+            // Notify() was called before we got here, consume it here without waiting and return immediately.
+            SignalState::Notified => *state = SignalState::Empty,
             // This should not be possible because our signal is created within a function and never handed out to any
             // other threads. If this is the case, we have a serious problem so we panic immediately to avoid anything
             // more problematic happening.

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -1,4 +1,3 @@
-use pollster;
 use std::time::{Duration, Instant};
 
 #[test]


### PR DESCRIPTION
Thanks for the great library!
This PR fixes the following clippy warnings:
- [`clippy::single_component_path_imports`](https://rust-lang.github.io/rust-clippy/master/index.html#single_component_path_imports)
- [`clippy::needless_return`](https://rust-lang.github.io/rust-clippy/master/index.html#needless_return)