### PR TITLE
Replace unsafe `std::pin::Pin::new_unchecked` with `std::pin::pin!`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -108,9 +108,6 @@ impl Wake for Signal {
 /// ```
 pub fn block_on<F: Future>(mut fut: F) -> F::Output {
     // Pin the future so that it can be polled.
-    // SAFETY: We shadow `fut` so that it cannot be used again. The future is now pinned to the stack and will not be
-    // moved until the end of this scope. This is, incidentally, exactly what the `pin_mut!` macro from `pin_utils`
-    // does.
     let mut fut = std::pin::pin!(fut);
 
     // Signal used to wake up the thread for polling as the future moves to completion. We need to use an `Arc`

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -111,7 +111,7 @@ pub fn block_on<F: Future>(mut fut: F) -> F::Output {
     // SAFETY: We shadow `fut` so that it cannot be used again. The future is now pinned to the stack and will not be
     // moved until the end of this scope. This is, incidentally, exactly what the `pin_mut!` macro from `pin_utils`
     // does.
-    let mut fut = unsafe { std::pin::Pin::new_unchecked(&mut fut) };
+    let mut fut = std::pin::pin!(fut);
 
     // Signal used to wake up the thread for polling as the future moves to completion. We need to use an `Arc`
     // because, although the lifetime of `fut` is limited to this function, the underlying IO abstraction might keep


### PR DESCRIPTION
Currently to locally pin a future unsafe [`std::pin::Pin::new_unchecked`](https://doc.rust-lang.org/std/pin/struct.Pin.html#method.new_unchecked) is being used.
This PR replaces that unsafe block with [`std::pin::pin!`](https://doc.rust-lang.org/std/pin/macro.pin.html) macro introduced in [Rust 1.68](https://github.com/rust-lang/rust/blob/stable/RELEASES.md#version-1680-2023-03-09) release.
