### PR TITLE
Improve the docs.rs situation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,3 +23,8 @@ pollster-macro = { version = "0.1", path = "macro", optional = true }
 [dev-dependencies]
 futures-timer = "3.0"
 tokio = { version = "1", features = ["sync"] }
+
+[package.metadata.docs.rs]
+all-features = true
+targets = []
+rustdoc-args = ["--cfg", "docsrs"]

--- a/macro/Cargo.toml
+++ b/macro/Cargo.toml
@@ -24,3 +24,6 @@ syn = { version = "1", default-features = false, features = [
 
 [dev-dependencies]
 pollster = { path = "..", features = ["macro"] }
+
+[package.metadata.docs.rs]
+targets = []

--- a/macro/src/lib.rs
+++ b/macro/src/lib.rs
@@ -20,6 +20,8 @@ use syn::{AttributeArgs, Error, ItemFn, Lit, Meta, MetaNameValue, NestedMeta, Re
 ///     my_fut.await;
 /// }
 /// ```
+///
+/// [`pollster::block_on`]: https://docs.rs/pollster/0.3.0/pollster/fn.block_on.html
 #[proc_macro_attribute]
 pub fn main(
     attr: proc_macro::TokenStream,
@@ -46,6 +48,8 @@ pub fn main(
 ///     my_fut.await;
 /// }
 /// ```
+///
+/// [`pollster::block_on`]: https://docs.rs/pollster/0.3.0/pollster/fn.block_on.html
 #[proc_macro_attribute]
 pub fn test(
     attr: proc_macro::TokenStream,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,5 @@
 #![doc = include_str!("../README.md")]
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 use std::{
     future::Future,


### PR DESCRIPTION
I noticed broken links on the proc-macros and them not showing as being re-exported on docs.rs.