### PR TITLE
Update `syn` to v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ async fn main() {
 
 Additionally if you have re-exported the crate with a different name then `pollster`, you have to specify it:
 ```rust,ignore
-#[pollster::main(crate = "renamed-pollster")]
+#[pollster::main(crate = renamed_pollster)]
 async fn main() {
     let my_fut = async {};
 

--- a/macro/Cargo.toml
+++ b/macro/Cargo.toml
@@ -16,7 +16,7 @@ proc-macro = true
 [dependencies]
 proc-macro2 = "1"
 quote = { version = "1", default-features = false }
-syn = { version = "1", default-features = false, features = [
+syn = { version = "2", default-features = false, features = [
     "full",
     "parsing",
     "printing",

--- a/macro/tests/main.rs
+++ b/macro/tests/main.rs
@@ -23,12 +23,18 @@ fn result() {
     main_result().unwrap();
 }
 
+#[pollster::main(crate = reexported_pollster)]
+async fn main_crate_path() {
+    ready(42).await;
+}
+
 #[pollster::main(crate = "reexported_pollster")]
-async fn main_crate() {
+async fn main_crate_str() {
     ready(42).await;
 }
 
 #[test]
 fn crate_() {
-    main_crate();
+    main_crate_path();
+    main_crate_str();
 }

--- a/macro/tests/test.rs
+++ b/macro/tests/test.rs
@@ -16,7 +16,12 @@ async fn result() -> Result<(), std::io::Error> {
     }
 }
 
+#[pollster::test(crate = reexported_pollster)]
+async fn crate_path() {
+    ready(42).await;
+}
+
 #[pollster::test(crate = "reexported_pollster")]
-async fn crate_() {
+async fn crate_str() {
     ready(42).await;
 }


### PR DESCRIPTION
This updates the `syn` dependency to v2.

The code got more simplified and `MetaNameValue` now supports taking a value that is not a string literal, so I added support to pass bare `Path`s and made it the default in the documentation.
To not introduce a breaking change I kept accepting a string as it is, including the tests.

The error messages are going to be a bit different, but functionally there should be no change.