### PR TITLE
Add performance benchmarks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [workspace]
 members = ["", "macro"]
-default-members = ["macro"]
+default-members = ["", "macro"]
 
 [package]
 name = "pollster"
@@ -14,6 +14,10 @@ edition = "2018"
 license = "Apache-2.0/MIT"
 readme = "README.md"
 
+[[bench]]
+name = "main"
+harness = false
+
 [features]
 macro = ["pollster-macro"]
 
@@ -23,6 +27,7 @@ pollster-macro = { version = "0.1", path = "macro", optional = true }
 [dev-dependencies]
 futures-timer = "3.0"
 tokio = { version = "1", features = ["sync"] }
+criterion = "0.4"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/benches/main.rs
+++ b/benches/main.rs
@@ -1,0 +1,63 @@
+use criterion::*;
+
+use core::future::{poll_fn, ready};
+use core::task::{Poll, Waker};
+use pollster::block_on;
+
+fn benches() {
+    let mut c = Criterion::default();
+
+    // Benchmark raw performance of pollster - processing of ready futures
+    c.bench_function("poll_ready", |b| {
+        b.iter(|| block_on(ready(black_box(false))))
+    });
+
+    // Benchmark how pollster fares with futures that return Pending,
+    // but immediately wake up the thread.
+    c.bench_function("wakeup_and_pending", |b| {
+        b.iter(|| {
+            let mut polled = false;
+            let fut = poll_fn(|cx| {
+                if !polled {
+                    polled = true;
+                    cx.waker().wake_by_ref();
+                    Poll::Pending
+                } else {
+                    Poll::Ready(())
+                }
+            });
+            block_on(fut)
+        })
+    });
+
+    // Benchmark how pollster fares with futures that get woken up from another thread.
+    let (tx, rx) = std::sync::mpsc::channel::<Waker>();
+
+    let thread = std::thread::spawn(move || {
+        for waker in rx.into_iter() {
+            waker.wake();
+        }
+    });
+
+    c.bench_function("wait_for_thread", |b| {
+        b.iter(|| {
+            let mut polled = false;
+            let fut = poll_fn(|cx| {
+                if !polled {
+                    polled = true;
+                    tx.send(cx.waker().clone()).unwrap();
+                    Poll::Pending
+                } else {
+                    Poll::Ready(())
+                }
+            });
+            block_on(fut)
+        })
+    });
+
+    core::mem::drop(tx);
+
+    thread.join().unwrap();
+}
+
+criterion_main!(benches);


### PR DESCRIPTION
Added 3 simple performance benchmarks, which should test how pollster fares performance wise.

Note that I needed to add "" to default members of workspace to trigger the benches. Not sure if the omission was intentional or not.