### PR TITLE
feat: relax FutureExt trait bound to extend IntoFuture impls instead

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ keywords = ["async", "minimal", "executor", "runtime", "block_on"]
 repository = "https://github.com/zesterer/pollster"
 authors = ["Joshua Barretto <joshua.s.barretto@gmail.com>"]
 edition = "2018"
+rust-version = "1.69"
 license = "Apache-2.0/MIT"
 readme = "README.md"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,7 @@ thread_local! {
 pub use pollster_macro::{main, test};
 
 /// An extension trait that allows blocking on a future in suffix position.
-pub trait FutureExt: Future {
+pub trait FutureExt: IntoFuture {
     /// Block the thread until the future is ready.
     ///
     /// # Example
@@ -42,7 +42,7 @@ pub trait FutureExt: Future {
     }
 }
 
-impl<F: Future> FutureExt for F {}
+impl<F: IntoFuture> FutureExt for F {}
 
 struct Signal {
     /// The thread that owns the signal.


### PR DESCRIPTION
Howdy!

This is a bit of an extension of #26, but more general.

Currently `FutureExt` only extends types that impl `Future`, allowing you to call `.block_on()` instead of `.await` on those types.

However this does *not* work for types that happen to impl `IntoFuture` instead, despite them also being capable of being `.await`-ed typically... Additionally, in [the documentation for `IntoFuture`](https://doc.rust-lang.org/1.97.0/core/future/trait.IntoFuture.html#await-desugaring), it describes how calling `.await` desugars into a `IntoFuture::into_future` invocation followed by the usual  `poll()`-ing to completion. 

As such, all `impl Future` types also impl `IntoFuture` by the nature of the blanket impl within [`std`/`core`](https://doc.rust-lang.org/1.97.0/src/core/future/into_future.rs.html#138-145), `impl<F: Future> IntoFuture for F`.

_As far as I can tell_, this change shouldn't break anything due to the above, including the MSRV (and as an aside, this also adds the MSRV to Cargo.toml).

--

My other intention with this PR is to potentially trigger a new release to crates.io, since the current `unsafe`-less version is quite nice, but is not currently available for mass consumption without adding a `git` dependency.

Lemme know if you have any questions!