### PR TITLE
Fix docs.rs build, don't use deprecated nightly feature

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,5 @@
 #![doc = include_str!("../README.md")]
-#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+#![cfg_attr(docsrs, feature(doc_cfg))]
 
 use std::{
     future::{Future, IntoFuture},


### PR DESCRIPTION
Agh, I forgot to re-add this after re-doing my changes (I oops'd my `stash`).

`doc_auto_cfg` [I think?] was a Nightly only feature, and got merged into `doc_cfg`, and any doc builds with `doc_auto_cfg` outright fail (as seen for 1.0.0, sadly #33).

Closes #33